### PR TITLE
rust update

### DIFF
--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -135,11 +135,13 @@ runs:
       run: |
         mkdir /tmp/ccache
         cd /tmp/ccache
-        wget -O ccache.tar.xz https://github.com/ccache/ccache/releases/download/v4.6.1/ccache-4.6.1-linux-x86_64.tar.xz
+        wget -O ccache.tar.xz https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-x86_64.tar.xz
         tar -xf ccache.tar.xz --strip-components=1
         chmod +x ccache
         sudo mv ccache /usr/local/bin/ccache
         ccache --show-config
+      env:
+        CCACHE_VERSION: 4.6.3
       shell: bash
 
     # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html#variable:CMAKE_%3CLANG%3E_COMPILER_LAUNCHER
@@ -293,7 +295,7 @@ runs:
         wget -O- https://github.com/rui314/mold/releases/download/v$MOLD_VERSION/mold-$MOLD_VERSION-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
         sudo chmod +x /usr/local/bin/mold
       env:
-        MOLD_VERSION: 1.3.1
+        MOLD_VERSION: 1.5.0
       shell: bash
 
     # DO NOT use eg "if: (!fromJSON(steps.check-mold-exists.outputs.mold-exists))"

--- a/prepare_rust/action.yml
+++ b/prepare_rust/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Install sccache"
     required: false
     default: "true"
+  skip_action_toolchain:
+    description: "Skip using actions-rs/toolchain@v1; useful when using a rust-toolchain.toml"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -25,6 +29,7 @@ runs:
     # Swatinem/rust-cache: "selecting a toolchain either by action or manual `rustup` calls should happen
     # before the plugin, as it uses the current rustc version as its cache key"
     - uses: actions-rs/toolchain@v1
+      if: ${{ !fromJSON(inputs.skip_action_toolchain) }}
       id: action-rs-toolchain
       with:
         profile: ${{ inputs.toolchain_profile }}
@@ -32,6 +37,12 @@ runs:
         components: ${{ inputs.toolchain_components }}
         # TODO override? or default: true?
         override: true
+
+    # https://github.com/actions-rs/toolchain/issues/126
+    - name: Setup rust toolchain
+      if: ${{ fromJSON(inputs.skip_action_toolchain) }}
+      run: rustup show
+      shell: bash
 
     # https://github.com/actions-rs/toolchain#outputs
     # Technically we could just use outputs.rustc b/c guaranteed to change for every new compiler/build

--- a/prepare_rust/action.yml
+++ b/prepare_rust/action.yml
@@ -69,7 +69,7 @@ runs:
       run: |
         mkdir /tmp/sscache
         cd /tmp/sscache
-        wget -c https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz -O - | tar -xz --strip-components 1
+        wget -c https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz -O - | tar -xz --strip-components 1
         chmod +x sccache
         sudo mv sccache /usr/local/bin/sccache
         sccache --version

--- a/rust-build-and-test/action.yml
+++ b/rust-build-and-test/action.yml
@@ -1,5 +1,15 @@
-name: "cmake-build-and-test"
-description: "Run CMake with CMakePreset.json to configure, build and test C/C++ source code."
+name: "rust-build-and-test"
+description: "cargo check + cargo test"
+
+inputs:
+  check_args:
+    description: "args passed to cargo check"
+    required: false
+    default: ""
+  test_args:
+    description: "args passed to cargo test"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -8,11 +18,13 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: check
+        args: ${{ inputs.check_args }}
 
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:
         command: test
+        args: ${{ inputs.test_args }}
 
     # TODO move into separate action? ideally into a JS action "post" that setup ccache?
     - name: Print ccache/sccache stats

--- a/rust-lint/action.yml
+++ b/rust-lint/action.yml
@@ -1,5 +1,15 @@
-name: "cmake-build-and-test"
+name: "rust-lint"
 description: "Run CMake with CMakePreset.json to configure, build and test C/C++ source code."
+
+inputs:
+  fmt_args:
+    description: "args passed to cargo fmt"
+    required: false
+    default: "-- --check"
+  clippy_args:
+    description: "args passed to cargo fmt"
+    required: false
+    default: "-- -D warnings"
 
 runs:
   using: "composite"
@@ -8,13 +18,13 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: fmt
-        args: --all -- --check
+        args: ${{ inputs.fmt_args }}
 
     - name: Run cargo clippy
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: -- -D warnings
+        args: ${{ inputs.clippy_args }}
 
     # TODO move into separate action? ideally into a JS action "post" that setup ccache?
     - name: Print ccache/sccache stats


### PR DESCRIPTION
- allow using a rust-toolchain.toml with new param `skip_action_toolchain`
- allow completely overriding clippy and fmt parameters
- bump ccache and sccache versions